### PR TITLE
Rebuild for libpq=13

### DIFF
--- a/.ci_support/linux_64_python3.6.____73_pypy.yaml
+++ b/.ci_support/linux_64_python3.6.____73_pypy.yaml
@@ -22,3 +22,6 @@ python:
 - 3.6.* *_73_pypy
 target_platform:
 - linux-64
+zip_keys:
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.6.____73_pypy.yaml
+++ b/.ci_support/linux_64_python3.6.____73_pypy.yaml
@@ -10,11 +10,7 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
-openssl:
-- 1.1.1
 pin_run_as_build:
-  openssl:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_64_python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_python3.6.____cpython.yaml
@@ -22,3 +22,6 @@ python:
 - 3.6.* *_cpython
 target_platform:
 - linux-64
+zip_keys:
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_python3.6.____cpython.yaml
@@ -10,11 +10,7 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
-openssl:
-- 1.1.1
 pin_run_as_build:
-  openssl:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_64_python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_python3.7.____cpython.yaml
@@ -22,3 +22,6 @@ python:
 - 3.7.* *_cpython
 target_platform:
 - linux-64
+zip_keys:
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_python3.7.____cpython.yaml
@@ -10,11 +10,7 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
-openssl:
-- 1.1.1
 pin_run_as_build:
-  openssl:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -22,3 +22,6 @@ python:
 - 3.8.* *_cpython
 target_platform:
 - linux-64
+zip_keys:
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -10,11 +10,7 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
-openssl:
-- 1.1.1
 pin_run_as_build:
-  openssl:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -22,3 +22,6 @@ python:
 - 3.9.* *_cpython
 target_platform:
 - linux-64
+zip_keys:
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -10,11 +10,7 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
-openssl:
-- 1.1.1
 pin_run_as_build:
-  openssl:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_aarch64_python3.6.____73_pypy.yaml
+++ b/.ci_support/linux_aarch64_python3.6.____73_pypy.yaml
@@ -14,11 +14,7 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
-openssl:
-- 1.1.1
 pin_run_as_build:
-  openssl:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_aarch64_python3.6.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.6.____cpython.yaml
@@ -14,11 +14,7 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
-openssl:
-- 1.1.1
 pin_run_as_build:
-  openssl:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_aarch64_python3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.7.____cpython.yaml
@@ -14,11 +14,7 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
-openssl:
-- 1.1.1
 pin_run_as_build:
-  openssl:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_aarch64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.8.____cpython.yaml
@@ -14,11 +14,7 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
-openssl:
-- 1.1.1
 pin_run_as_build:
-  openssl:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_aarch64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.9.____cpython.yaml
@@ -14,11 +14,7 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
-openssl:
-- 1.1.1
 pin_run_as_build:
-  openssl:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_ppc64le_python3.6.____73_pypy.yaml
+++ b/.ci_support/linux_ppc64le_python3.6.____73_pypy.yaml
@@ -10,11 +10,7 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
-openssl:
-- 1.1.1
 pin_run_as_build:
-  openssl:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_ppc64le_python3.6.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.6.____cpython.yaml
@@ -10,11 +10,7 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
-openssl:
-- 1.1.1
 pin_run_as_build:
-  openssl:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_ppc64le_python3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.7.____cpython.yaml
@@ -10,11 +10,7 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
-openssl:
-- 1.1.1
 pin_run_as_build:
-  openssl:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_ppc64le_python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.8.____cpython.yaml
@@ -10,11 +10,7 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
-openssl:
-- 1.1.1
 pin_run_as_build:
-  openssl:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_ppc64le_python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.9.____cpython.yaml
@@ -10,11 +10,7 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
-openssl:
-- 1.1.1
 pin_run_as_build:
-  openssl:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -45,8 +45,12 @@ fi
 if [ -z "${DOCKER_IMAGE}" ]; then
     SHYAML_INSTALLED="$(shyaml -h || echo NO)"
     if [ "${SHYAML_INSTALLED}" == "NO" ]; then
-        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Falling back to condaforge/linux-anvil-comp7"
-        DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Trying to parse with coreutils"
+        DOCKER_IMAGE=$(cat .ci_support/${CONFIG}.yaml | grep '^docker_image:$' -A 1 | tail -n 1 | cut -b 3-)
+        if [ "${DOCKER_IMAGE}" = "" ]; then
+            echo "No docker_image entry found in ${CONFIG}. Falling back to condaforge/linux-anvil-comp7"
+            DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        fi
     else
         DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
     fi
@@ -64,8 +68,8 @@ fi
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - have_openssl.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,13 +22,13 @@ requirements:
   host:
     - python
     - pip
-    - openssl  # [win]
+    - openssl  # [not linux]
     - postgresql
   run:
     - python
     # libpq is a repackaging of only the library to connect to postgres
     - libpq
-    - openssl  # [win]
+    - openssl  # [not linux]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,13 +22,13 @@ requirements:
   host:
     - python
     - pip
-    - openssl
+    - openssl  # [win]
     - postgresql
   run:
     - python
     # libpq is a repackaging of only the library to connect to postgres
     - libpq
-    - openssl
+    - openssl  # [win]
 
 test:
   imports:


### PR DESCRIPTION
This PR rebuilds this feedstock to link against libpq=13, which is required by other packages (e.g. `qt`).

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
