### PR TITLE
Add 2.x.x abi migration branch

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,6 @@
+bot:
+  abi_migration_branches:
+  - 2.x.x
 build_platform:
   osx_arm64: osx_64
 conda_build:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
*  Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* Ensured the license file is being packaged.

I believe psycopg 2 needs to stick around for a while:

- psycopg2 and psycopg3 are not compatible, so folks need time to migrate code bases
- psycopg2 needs to keep marching forward with migrations applied so to not create dependency islands
- psycopg2 and psycopg packages can co-exist within an environment without issue.