### PR TITLE
bump build number to build against updated postgresql

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "psycopg" %}
 {% set version = "3.1.14" %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 package:
   name: psycopg-split


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

A segfault is being reproduced in #94, I sort of wonder if an updated build here would help solve it. This build should see a newer postgresql with proper openssl 3.2 support.  build 0 appeared to get postgresql 16.1 build 0 and a mix of openssl.  I could be way off, as usual :(