### PR TITLE
remove `backports.zoneinfo` from deps of `psycopg`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "psycopg" %}
 {% set version = "3.2.5" %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 package:
   name: psycopg-split
@@ -68,14 +68,12 @@ outputs:
       host:
         - python
         - pip
-        - backports.zoneinfo  # [py<39]
         - postgresql
         - setuptools
         - tzdata  # [win]
       run:
         - python
         - {{ pin_subpackage('psycopg-c', max_pin='x.x.x.x.x.x') }}
-        - backports.zoneinfo >=0.2.0  # [py<39]
         # libpq is a repackaging of only the library to connect to postgres
         - libpq
         - typing-extensions >=4.6  # [py<313]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

They do not support py<39 in `3.2.5` so they have removed the requirement of `backports.zoneinfo`.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
