### PR TITLE
Bump Build, get psycopg2 & psycopg2-binary in sync v 2.9.10

### DIFF
--- a/build-locally.py
+++ b/build-locally.py
@@ -106,9 +106,7 @@ def main(args=None):
         action="store_true",
         help="Setup debug environment using `conda debug`",
     )
-    p.add_argument(
-        "--output-id", help="If running debug, specify the output to setup."
-    )
+    p.add_argument("--output-id", help="If running debug, specify the output to setup.")
 
     ns = p.parse_args(args=args)
     verify_config(ns)
@@ -124,9 +122,7 @@ def main(args=None):
         elif ns.config.startswith("win"):
             run_win_build(ns)
     finally:
-        recipe_license_file = os.path.join(
-            "recipe", "recipe-scripts-license.txt"
-        )
+        recipe_license_file = os.path.join("recipe", "recipe-scripts-license.txt")
         if os.path.exists(recipe_license_file):
             os.remove(recipe_license_file)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,7 @@ outputs:
     script: install_psycopg2-binary.sh
     build:
       noarch: python
-      skip: true  # [not linux or py!=313 or ppc64le or aarch64]
+      skip: true  # [not linux or py!=39 or ppc64le or aarch64]
     requirements:
       host:
         - python {{ python_min }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,7 @@ outputs:
     script: install_psycopg2-binary.sh
     build:
       noarch: python
-      skip: true  # [not linux or py!=38 or ppc64le or aarch64]
+      skip: true  # [not linux or py!=313 or ppc64le or aarch64]
     requirements:
       host:
         - python {{ python_min }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-have-openssl.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ name }}


### PR DESCRIPTION
https://anaconda.org/conda-forge/psycopg2/files - Version 2.9.10 https://anaconda.org/conda-forge/psycopg2-binary/files - Version 2.9.9

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Bump Build, get psycopg2 & psycopg2-binary in sync v2.9.10
https://anaconda.org/conda-forge/psycopg2/files - Latest version is v2.9.10
https://anaconda.org/conda-forge/psycopg2-binary/files- Latest version is v2.9.9

Causes failure on 
 - https://github.com/conda-forge/opentelemetry-instrumentation-psycopg2-feedstock/pull/27

Current Error Message
```
import: 'opentelemetry.instrumentation'
+ pip check
psycopg2-binary 2.9 has requirement psycopg2==2.9, but you have psycopg2 2.9.10.

```

<!--
Please add any other relevant info below:
-->
